### PR TITLE
Update Semantic-Release configuration and version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
 
   Semantic-Release:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/development')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging' )
     needs: Run-A-Pixi-Job
     concurrency: release
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snakemake_kubernetes_api"
-version = "0.1.10-alpha.2"
+version = "0.1.11"
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,6 @@ match = "(stg|staging)"
 prerelease_token = "rc"
 prerelease = true
 
-[tool.semantic_release.branches.develop]
-match = "(dev|development)"
-prerelease_token = "alpha"
-prerelease = true
-
-
 [tool.semantic_release.changelog]
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []

--- a/src/snakekube/main.py
+++ b/src/snakekube/main.py
@@ -1,3 +1,3 @@
 
 
-__version__ = "0.1.10-alpha.2"
+__version__ = "0.1.11"


### PR DESCRIPTION
This pull request updates the Semantic-Release configuration and version. The configuration is modified to include the 'staging' branch in the 'Semantic-Release' job. Additionally, the version in the 'pyproject.toml' and 'main.py' files is updated from '0.1.10-alpha.2' to '0.1.11'.